### PR TITLE
Improve storage module tests

### DIFF
--- a/storage/storage.py
+++ b/storage/storage.py
@@ -1,0 +1,71 @@
+import json
+from pathlib import Path
+from typing import Any, Dict
+import logging
+
+USERS_FILE = Path(__file__).resolve().parent / "users.json"
+
+
+def load_users() -> Dict[str, Any]:
+    """Загружает все данные пользователей из users.json."""
+    try:
+        if USERS_FILE.exists():
+            with open(USERS_FILE, "r", encoding="utf-8") as f:
+                return json.load(f)
+    except (OSError, json.JSONDecodeError) as e:
+        logging.error("Failed to load users from %s: %s", USERS_FILE, e)
+    return {}
+
+
+def save_users(users: Dict[str, Any]) -> None:
+    """Сохраняет все данные обратно в файл."""
+    try:
+        USERS_FILE.parent.mkdir(parents=True, exist_ok=True)
+        with open(USERS_FILE, "w", encoding="utf-8") as f:
+            json.dump(users, f, indent=2, ensure_ascii=False)
+    except OSError as e:
+        logging.error("Failed to save users to %s: %s", USERS_FILE, e)
+
+
+def get_user(chat_id: int) -> Dict[str, Any]:
+    """Возвращает словарь с настройками конкретного пользователя."""
+    users = load_users()
+    chat_id_str = str(chat_id)
+    if chat_id_str not in users:
+        init_user(chat_id, "")
+        return load_users().get(chat_id_str, {})
+    return users[chat_id_str]
+
+
+def update_user(chat_id: int, key: str, value: Any) -> None:
+    """Обновляет поле пользователя и сохраняет."""
+    users = load_users()
+    user = users.get(str(chat_id), {})
+    user[key] = value
+    users[str(chat_id)] = user
+    save_users(users)
+
+
+def init_user(chat_id: int, address: str) -> None:
+    """Создаёт новый профиль пользователя с базовыми значениями."""
+    users = load_users()
+    if str(chat_id) not in users:
+        users[str(chat_id)] = {
+            "address": address,
+            "hf_thresholds": [1.5, 1.3],
+            "sr_thresholds": [150, 130],
+            "lp_pairs": [],
+            "lp_fees_threshold": 20,
+            "price_alerts": {
+                "eth": 10,
+                "btc": 5,
+            },
+            "alerts": {
+                "hf": True,
+                "sr": True,
+                "lp_range": True,
+                "lp_fees": True,
+                "prices": True,
+            },
+        }
+        save_users(users)

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,55 @@
+import json
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import storage.storage as s
+
+
+def test_load_users_missing(tmp_path, monkeypatch):
+    test_file = tmp_path / "users.json"
+    monkeypatch.setattr(s, "USERS_FILE", test_file)
+    assert s.load_users() == {}
+
+
+def test_init_and_update_user(tmp_path, monkeypatch):
+    test_file = tmp_path / "users.json"
+    monkeypatch.setattr(s, "USERS_FILE", test_file)
+
+    s.init_user(123, "0xabc")
+    user = s.get_user(123)
+    assert user["address"] == "0xabc"
+    assert user["lp_fees_threshold"] == 20
+    assert user["hf_thresholds"] == [1.5, 1.3]
+    assert user["price_alerts"]["eth"] == 10
+
+    s.update_user(123, "lp_fees_threshold", 25)
+    updated = s.get_user(123)
+    assert updated["lp_fees_threshold"] == 25
+
+    s.update_user(123, "address", "привет")
+
+    with open(test_file, encoding="utf-8") as f:
+        data = json.load(f)
+    assert data[str(123)]["lp_fees_threshold"] == 25
+    assert "привет" in open(test_file, encoding="utf-8").read()
+
+
+def test_load_users_corrupt(tmp_path, monkeypatch):
+    test_file = tmp_path / "users.json"
+    test_file.write_text("{invalid json", encoding="utf-8")
+    monkeypatch.setattr(s, "USERS_FILE", test_file)
+    assert s.load_users() == {}
+
+
+def test_get_user_creates_new(tmp_path, monkeypatch):
+    test_file = tmp_path / "users.json"
+    monkeypatch.setattr(s, "USERS_FILE", test_file)
+
+    user = s.get_user(555)
+    assert user["address"] == ""
+    assert user["hf_thresholds"] == [1.5, 1.3]
+    with open(test_file, encoding="utf-8") as f:
+        data = json.load(f)
+    assert str(555) in data


### PR DESCRIPTION
## Summary
- refine `storage/storage.py` error handling with logging
- add pytest suite for storage module
- streamline `get_user` logic

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6863c78a7ed08320b285b330870afdec