### PR TITLE
Implement monitoring loop for user alerts

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,6 +3,7 @@ from aiogram import Bot, Dispatcher
 
 from config import load_config
 from handlers import register_handlers
+from services.monitor import monitor_all_users
 
 
 async def main() -> None:
@@ -11,6 +12,7 @@ async def main() -> None:
     dp = Dispatcher(bot)
 
     register_handlers(dp)
+    asyncio.create_task(monitor_all_users(bot))
 
     await dp.start_polling()
 

--- a/services/aave.py
+++ b/services/aave.py
@@ -4,4 +4,9 @@ class AaveService:
     async def get_health_factor(self, address: str):
         """Fetch health factor for a given address."""
         # TODO: integrate with Aave API
-        pass
+        return 1.4
+
+    async def get_safety_ratio(self, address: str):
+        """Fetch safety ratio for a given address."""
+        # TODO: integrate with Aave API
+        return 140

--- a/services/coingecko.py
+++ b/services/coingecko.py
@@ -4,4 +4,5 @@ class CoingeckoService:
     async def get_price(self, asset: str):
         """Return current price for the given asset."""
         # TODO: integrate with Coingecko API
-        pass
+        prices = {"eth": 1800, "btc": 30000}
+        return prices.get(asset.lower(), 0)

--- a/services/monitor.py
+++ b/services/monitor.py
@@ -1,0 +1,112 @@
+import asyncio
+import logging
+import time
+from typing import Dict, Tuple
+
+from aiogram import Bot
+
+from storage.storage import load_users, update_user
+
+from .aave import AaveService
+from .revert import RevertService
+from .coingecko import CoingeckoService
+
+
+class Monitor:
+    """Periodically check user positions and send alerts."""
+
+    def __init__(self, bot: Bot, interval: int = 60):
+        self.bot = bot
+        self.interval = interval
+        self.aave = AaveService()
+        self.revert = RevertService()
+        self.coingecko = CoingeckoService()
+        self._last_alerts: Dict[Tuple[int, str], float] = {}
+
+    async def _send_alert(self, chat_id: int, category: str, text: str) -> None:
+        now = time.monotonic()
+        key = (chat_id, category)
+        if now - self._last_alerts.get(key, 0) < 300:
+            return
+        try:
+            await self.bot.send_message(chat_id, text)
+            self._last_alerts[key] = now
+        except Exception as e:  # pragma: no cover - network related
+            logging.error("Failed to send alert: %s", e)
+
+    async def check_user(self, chat_id: int, user: dict) -> None:
+        address = user.get("address")
+        if not address:
+            return
+        alerts = user.get("alerts", {})
+        if alerts.get("hf"):
+            hf = await self.aave.get_health_factor(address)
+            for threshold in user.get("hf_thresholds", []):
+                if hf < threshold:
+                    await self._send_alert(
+                        chat_id,
+                        "hf",
+                        f"⚠️ Health Factor упал ниже {threshold}! (Текущее значение: {hf})",
+                    )
+                    break
+        if alerts.get("sr"):
+            sr = await self.aave.get_safety_ratio(address)
+            for threshold in user.get("sr_thresholds", []):
+                if sr < threshold:
+                    await self._send_alert(
+                        chat_id,
+                        "sr",
+                        f"⚠️ Safety Ratio упал ниже {threshold}! (Текущее значение: {sr})",
+                    )
+                    break
+        positions = []
+        if alerts.get("lp_range") or alerts.get("lp_fees"):
+            positions = await self.revert.get_active_lps(address)
+        if alerts.get("lp_range"):
+            for p in positions:
+                if not p.get("in_range", True):
+                    await self._send_alert(
+                        chat_id,
+                        f"lp_range_{p['pair']}",
+                        f"⚠️ Пара {p['pair']} вышла из диапазона!",
+                    )
+        if alerts.get("lp_fees"):
+            threshold = user.get("lp_fees_threshold", 0)
+            for p in positions:
+                if p.get("fees_usd", 0) > threshold:
+                    await self._send_alert(
+                        chat_id,
+                        f"lp_fees_{p['pair']}",
+                        f"💰 Доход по паре {p['pair']} превысил ${threshold}!",
+                    )
+        if alerts.get("prices"):
+            price_alerts = user.get("price_alerts", {})
+            for asset, percent in price_alerts.items():
+                price = await self.coingecko.get_price(asset)
+                last_key = f"{asset}_price"
+                prev = user.get(last_key)
+                if prev is not None:
+                    change = abs(price - prev) / prev * 100 if prev else 0
+                    if change > percent:
+                        arrow = "📉" if price < prev else "📈"
+                        await self._send_alert(
+                            chat_id,
+                            f"price_{asset}",
+                            f"{arrow} {asset.upper()} изменился на {round(change, 2)}%",
+                        )
+                update_user(chat_id, last_key, price)
+
+    async def run(self) -> None:
+        while True:
+            users = load_users()
+            for chat_id_str, user in users.items():
+                try:
+                    await self.check_user(int(chat_id_str), user)
+                except Exception as e:  # pragma: no cover - runtime logging
+                    logging.error("Monitor error for %s: %s", chat_id_str, e)
+            await asyncio.sleep(self.interval)
+
+
+async def monitor_all_users(bot: Bot, interval: int = 60) -> None:
+    monitor = Monitor(bot, interval)
+    await monitor.run()

--- a/services/revert.py
+++ b/services/revert.py
@@ -4,4 +4,7 @@ class RevertService:
     async def get_active_lps(self, address: str):
         """Fetch active LP positions for a given address."""
         # TODO: integrate with Revert API
-        pass
+        return [
+            {"pair": "ETH/USDC", "in_range": False, "fees_usd": 25},
+            {"pair": "WBTC/ETH", "in_range": True, "fees_usd": 5},
+        ]

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -1,0 +1,67 @@
+import sys
+from pathlib import Path
+import asyncio
+import types
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+# provide minimal aiogram stub
+aiogram_stub = types.ModuleType("aiogram")
+aiogram_stub.Bot = object
+aiogram_stub.Dispatcher = object
+aiogram_stub.types = types.SimpleNamespace(Message=object)
+sys.modules['aiogram'] = aiogram_stub
+sys.modules['aiogram.filters'] = types.SimpleNamespace(Command=object)
+
+# dummy Bot used by Monitor
+class DummyBot:
+    def __init__(self):
+        self.sent = []
+
+    async def send_message(self, chat_id, text):
+        self.sent.append((chat_id, text))
+
+import storage.storage as s
+from services.monitor import Monitor
+
+
+def setup_user(tmp_path, alerts=None):
+    s.USERS_FILE = tmp_path / 'users.json'
+    s.init_user(1, '0xabc')
+    if alerts is not None:
+        s.update_user(1, 'alerts', alerts)
+    return s.get_user(1)
+
+
+def test_check_user_sends_expected_alerts(tmp_path, monkeypatch):
+    monkeypatch.setattr('services.monitor.time.monotonic', lambda: 1000)
+    user = setup_user(tmp_path)
+    bot = DummyBot()
+    mon = Monitor(bot)
+    asyncio.run(mon.check_user(1, user))
+    texts = [t for _, t in bot.sent]
+    assert 'Health Factor' in texts[0]
+    assert 'Safety Ratio' in texts[1]
+    assert 'вышла из диапазона' in texts[2]
+    assert 'превысил $20' in texts[3]
+
+
+def test_price_alert_and_state_update(tmp_path, monkeypatch):
+    monkeypatch.setattr('services.monitor.time.monotonic', lambda: 1000)
+    setup_user(tmp_path, alerts={'prices': True})
+    s.update_user(1, 'price_alerts', {'eth': 5})
+    s.update_user(1, 'eth_price', 2000)
+    bot = DummyBot()
+    mon = Monitor(bot)
+    asyncio.run(mon.check_user(1, s.get_user(1)))
+    assert any(text.startswith('📉 ETH изменился') for _, text in bot.sent)
+    assert s.get_user(1)['eth_price'] == 1800
+
+
+def test_send_alert_throttle(monkeypatch):
+    bot = DummyBot()
+    mon = Monitor(bot)
+    monkeypatch.setattr('services.monitor.time.monotonic', lambda: 1000)
+    asyncio.run(mon._send_alert(1, 'hf', 'first'))
+    asyncio.run(mon._send_alert(1, 'hf', 'second'))
+    assert bot.sent == [(1, 'first')]


### PR DESCRIPTION
## Summary
- stub out service methods to return mock data
- implement monitor service to check alerts
- run monitor in background in main

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863ea8e7b248320b57e2ed128adcbbf